### PR TITLE
Add dividers/creatorElement to VerticalBar

### DIFF
--- a/src/Components/VerticalBar.js
+++ b/src/Components/VerticalBar.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
+import { Divider } from "@material-ui/core";
 import PropTypes from "prop-types";
 
 const useStyles = makeStyles(theme => ({
@@ -35,6 +36,13 @@ const VerticalBar = props => {
   return (
     <div className={classes.container}>
       <div className={classes.logoArea}>{props.upperElement}</div>
+      {props.useDividers && <Divider />}
+      {props.creatorElement && (
+        <div>
+          <div className={classes.logoArea}>{props.creatorElement}</div>
+          {props.useDividers && <Divider />}
+        </div>
+      )}
       <div className={classes.navigationArea}>
         {props.navigationList.map((element, index) => {
           return (
@@ -43,6 +51,7 @@ const VerticalBar = props => {
             </div>
           );
         })}
+        {props.useDividers && <Divider />}
       </div>
       <div className={classes.accountArea}>{props.lowerElement}</div>
     </div>
@@ -51,16 +60,20 @@ const VerticalBar = props => {
 
 VerticalBar.propTypes = {
   upperElement: PropTypes.node,
+  creatorElement: PropTypes.node,
   navigationList: PropTypes.array,
   lowerElement: PropTypes.node.isRequired,
   backgroundColor: PropTypes.string,
+  useDividers: PropTypes.bool,
   unsetAccountAreaPadding: PropTypes.bool
 };
 VerticalBar.defaultProps = {
   upperElement: <div></div>,
+  creatorElement: null,
   navigationList: [<div></div>],
   lowerElement: <div></div>,
   backgroundColor: "#424242",
+  useDividers: false,
   unsetAccountAreaPadding: false
 };
 


### PR DESCRIPTION
- Add customizable props to `VerticalBar`
   - `useDividers : Boolean` to add dividers between navigation group
   - `creatorElement : Element` to separate context menu from navigation group