### PR TITLE
Add customization props to `VerticalBar`

### DIFF
--- a/src/Components/VerticalBar.js
+++ b/src/Components/VerticalBar.js
@@ -38,10 +38,10 @@ const VerticalBar = props => {
       <div className={classes.logoArea}>{props.upperElement}</div>
       {props.useDividers && <Divider />}
       {props.creatorElement && (
-        <div>
+        <>
           <div className={classes.logoArea}>{props.creatorElement}</div>
           {props.useDividers && <Divider />}
-        </div>
+        </>
       )}
       <div className={classes.navigationArea}>
         {props.navigationList.map((element, index) => {


### PR DESCRIPTION
- Add customization props to `VerticalBar`
    - `useDividers : Boolean` to add dividers between navigation group
    - `creatorElement : Element` to separate context menu from navigation group