### PR TITLE
[FP - 1552] - Added the ability to not render the theme toggler

### DIFF
--- a/src/Components/ProfileMenu.js
+++ b/src/Components/ProfileMenu.js
@@ -116,8 +116,7 @@ ProfileMenu.defaultProps = {
   version: "",
   extraItems: [],
   isDarkTheme: true,
-  handleLogout: () => console.log("logout"),
-  handleToggleTheme: () => console.log("toggle")
+  handleLogout: () => console.log("logout")
 };
 
 export default ProfileMenu;


### PR DESCRIPTION
We need to add the ability to not render the theme toggler.
The aim of this PR is to not render the toggle if no `handleThemeToggle` function is passed to the profile menu.