### PR TITLE
Bugfix/FP-1557 - Abstract Modal should accept text or components for the confirm and cancel actions

### DIFF
--- a/src/Components/Modal/AbstractModal.js
+++ b/src/Components/Modal/AbstractModal.js
@@ -107,12 +107,12 @@ const AbstractModal = props => {
         <CardActions>
           {props.hasSubmitButton && (
             <Button color={props.submitColor} onClick={submit}>
-              {`${i18n.t(props.submitText)}`}
+              {props.submitText}
             </Button>
           )}
           {props.hasCancelButton && (
             <Button onClick={cancel} color={props.cancelColor}>
-              {`${i18n.t(props.cancelText)}`}
+              {props.cancelText}
             </Button>
           )}
         </CardActions>
@@ -141,10 +141,10 @@ AbstractModal.defaultProps = {
   onSubmit: () => {},
   onCancel: () => {},
   open: false,
-  title: "New",
-  submitText: "Confirm",
+  title: i18n.t("New"),
+  submitText: i18n.t("Confirm"),
   submitColor: "primary",
-  cancelText: "Cancel",
+  cancelText: i18n.t("Cancel"),
   cancelColor: "secondary",
   width: "25%",
   height: "25%",


### PR DESCRIPTION
https://movai.atlassian.net/browse/FP-1557

This PR fixes the cases where the apps using the AbstractModal provide a component to submitText prop and it's wrongly displayed and [Object object]. 

Tests:
- In TaskManager, when clicking the confirm button, a loading should be displayed. Check the ticket description if you are not able to generate tasks.
- If not providing a submitText or cancelText, both should be localized by default

The reason for the bug is:
The AbstractModal component receives the `submitText` and `cancelText` props. 
We have several applications using these props not only as text, but as components, for example. 
So the `submitText` should not be localized by default when the prop is supplied to the component, because this way, the applications lose the ability to control if the text they provide is going to be localized are not.


