### PR TITLE
FP-1581 : Avoid app crash on token expiration

### DIFF
--- a/src/Components/HOCs/withAuthentication.js
+++ b/src/Components/HOCs/withAuthentication.js
@@ -77,7 +77,7 @@ export default function withAuthentication(Component, appName) {
                   loggedIn: res
                 }));
               })
-              .catch(e =>
+              .catch(error =>
                 console.log("Error while trying to refresh the tokens", error)
               ),
           timeToRun


### PR DESCRIPTION
FP-1581 : Avoid app crash on token expiration

When the token expired, inside the catch block it was referencing to a not defined variable. Which caused app crash.