### PR TITLE
FP-1297 : Pass redirect argument to stay on IDE-CE on logout

### DIFF
--- a/src/Components/HOCs/withAuthentication.js
+++ b/src/Components/HOCs/withAuthentication.js
@@ -94,9 +94,10 @@ export default function withAuthentication(Component, appName) {
 
     /**
      * handleLogOut - log out the user
+     * @param {string} redirect : Redirect URL location
      */
-    const handleLogOut = () => {
-      Authentication.logout();
+    const handleLogOut = redirect => {
+      Authentication.logout(redirect);
     };
 
     /**


### PR DESCRIPTION
[FP-1297 : CE: Should login directly in IDE](https://movai.atlassian.net/browse/FP-1297)

This implementation allow the app to pass an argument of the redirect URL location on logout. This allow IDE-CE to pass its own URL location to stay on it (not going to the launcher) on logout