### PR TITLE
Bump lib-core version to the one matching 2.2.2 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/runtime": "^7.15.4",
         "@date-io/date-fns": "^1.3.13",
         "@material-ui/pickers": "^3.3.10",
-        "@mov-ai/mov-fe-lib-core": "^1.0.41-0",
+        "@mov-ai/mov-fe-lib-core": "^1.0.42-0",
         "clsx": "^1.1.1",
         "fontsource-open-sans": "^3.0.9",
         "fontsource-roboto": "^3.0.3",
@@ -4040,9 +4040,9 @@
       }
     },
     "node_modules/@mov-ai/mov-fe-lib-core": {
-      "version": "1.0.41-0",
-      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-core/1.0.41-0/03ab21105c79071b60ec569dd71b18f12b500a07444a58fb06f3e2468f7e8b5c",
-      "integrity": "sha512-nPVDhmWCbA049keGYvsnkpFMapAf3vBBBjIx/BTRncAj0NSwA1BgaEsIhvNx1fIejUNG0MNqvxTADlPFOzEkLA==",
+      "version": "1.0.42-0",
+      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-core/1.0.42-0/c4fb6ed90139cea53c41e851407bf4b9c38b423bfedfc9293700e14a287b021d",
+      "integrity": "sha512-OtYfSsMT2bRFG2SLGw1Y7T2AlI9iOsxsfqdLv7QRR12ovB+b94bp5y8MGv82pkKdzj+N44lOW68LRxj9GsTezw==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
@@ -39804,9 +39804,9 @@
       "dev": true
     },
     "@mov-ai/mov-fe-lib-core": {
-      "version": "1.0.41-0",
-      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-core/1.0.41-0/03ab21105c79071b60ec569dd71b18f12b500a07444a58fb06f3e2468f7e8b5c",
-      "integrity": "sha512-nPVDhmWCbA049keGYvsnkpFMapAf3vBBBjIx/BTRncAj0NSwA1BgaEsIhvNx1fIejUNG0MNqvxTADlPFOzEkLA==",
+      "version": "1.0.42-0",
+      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-core/1.0.42-0/c4fb6ed90139cea53c41e851407bf4b9c38b423bfedfc9293700e14a287b021d",
+      "integrity": "sha512-OtYfSsMT2bRFG2SLGw1Y7T2AlI9iOsxsfqdLv7QRR12ovB+b94bp5y8MGv82pkKdzj+N44lOW68LRxj9GsTezw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@babel/runtime": "^7.15.4",
     "@date-io/date-fns": "^1.3.13",
     "@material-ui/pickers": "^3.3.10",
-    "@mov-ai/mov-fe-lib-core": "^1.0.41-0",
+    "@mov-ai/mov-fe-lib-core": "^1.0.42-0",
     "clsx": "^1.1.1",
     "fontsource-open-sans": "^3.0.9",
     "fontsource-roboto": "^3.0.3",


### PR DESCRIPTION
Following PR https://github.com/MOV-AI/frontend-npm-lib-core/pull/66, we need to update the lib-react package dependencies version for lib-core
