### PR TITLE
FP-2030 : Add visible backdrop on select popover

### DIFF
--- a/src/Components/Select.js
+++ b/src/Components/Select.js
@@ -11,17 +11,33 @@ const useStyles = makeStyles(theme => ({
   formControl: {
     margin: theme.spacing(1),
     minWidth: 120
+  },
+  backdrop: {
+    "& div[aria-hidden=true]": {
+      backgroundColor: "black !important",
+      opacity: 0.5,
+      visibility: "visible"
+    }
   }
 }));
 
 const Select = props => {
+  const {
+    variant,
+    style,
+    label,
+    options,
+    noneOption,
+    noneOptionConfig,
+    ...otherProps
+  } = props;
   const classes = useStyles();
 
-  let noneOption = <div></div>;
-  if (props.noneOption) {
-    noneOption = (
-      <MenuItem value={props.noneOptionConfig.value}>
-        <em>{props.noneOptionConfig.text}</em>
+  let noneOptionEL = <div></div>;
+  if (noneOption) {
+    noneOptionEL = (
+      <MenuItem value={noneOptionConfig.value}>
+        <em>{noneOptionConfig.text}</em>
       </MenuItem>
     );
   }
@@ -29,26 +45,22 @@ const Select = props => {
   return (
     <FormControl
       data-testid="section_select-wrapper"
-      variant={props.variant}
+      variant={variant}
       className={classes.formControl}
-      style={props.style}
-      hiddenLabel={props.label === undefined ? true : false}
+      style={style}
+      hiddenLabel={label === undefined ? true : false}
     >
       <InputLabel data-testid="input_label" id="movai-react-select">
-        {props.label}
+        {label}
       </InputLabel>
       <MaterialSelect
+        MenuProps={{ PopoverClasses: { root: classes.backdrop } }}
         data-testid="section_select"
         labelId="movai-react-select"
-        id={props.id}
-        value={props.value}
-        onChange={props.onChange}
-        inputProps={props.inputProps}
-        multiple={props.multiple}
-        renderValue={props.renderValue}
+        {...otherProps}
       >
-        {noneOption}
-        {props.options.map((element, index) => {
+        {noneOptionEL}
+        {options.map((element, index) => {
           return (
             <MenuItem
               data-testid="output_menu-item"
@@ -86,8 +98,8 @@ Select.propTypes = {
   inputProps: PropTypes.object
 };
 Select.defaultProps = {
-  value: "option2",
-  options: ["option1", "option2", "option3"],
+  value: "",
+  options: [],
   variant: "filled",
   noneOption: true,
   noneOptionConfig: {

--- a/stories/Select.stories.js
+++ b/stories/Select.stories.js
@@ -2,11 +2,66 @@ import React from "react";
 import Select from "../src/Components/Select";
 
 export default {
-  title: "Select"
+  title: "Select",
+  argTypes: {
+    multiple: {
+      control: "boolean"
+    }
+  }
 };
 
-export const select = () => <Select></Select>;
+const NONE_OPTION_VALUE = "";
+const ALL_ROLES = {
+  DefaultRole: { Label: "DefaultRole" },
+  admin: { Label: "admin" },
+  operator: { Label: "operator" }
+};
 
-select.story = {
-  name: "simple select"
+const Template = props => {
+  const { multiple } = props;
+  const [emptyValue, setEmptyValue] = React.useState(multiple ? [] : "");
+  const [selectedRoles, setSelectedRoles] = React.useState(emptyValue);
+  const [selectorProps, setSelectorProps] = React.useState({});
+
+  React.useEffect(() => {
+    if (multiple) {
+      setSelectorProps({ renderValue: selected => selected.join(", ") });
+      setEmptyValue([]);
+      setSelectedRoles([]);
+    } else {
+      setSelectorProps({});
+      setEmptyValue("");
+      setSelectedRoles("");
+    }
+  }, [multiple]);
+
+  const handleRolesChange = evt => {
+    let newSelectedRoles = evt.target.value;
+    if (multiple && newSelectedRoles.includes(NONE_OPTION_VALUE))
+      newSelectedRoles = emptyValue;
+    setSelectedRoles(newSelectedRoles);
+  };
+
+  const getValue = () => {
+    if (multiple && typeof selectedRoles !== "object") return [];
+    else return selectedRoles;
+  };
+
+  return (
+    <Select
+      label={"Role"}
+      value={getValue()}
+      multiple={multiple}
+      onChange={handleRolesChange}
+      options={Object.keys(ALL_ROLES)}
+      noneOptionConfig={{ value: NONE_OPTION_VALUE, text: "None" }}
+      {...selectorProps}
+    ></Select>
+  );
+};
+
+export const Selector = Template.bind({});
+
+Selector.args = {
+  multiple: true
 };


### PR DESCRIPTION
[FP-2030 : Add visible backdrop on select popover](https://movai.atlassian.net/browse/FP-2030)

Test steps:
- Open lib-react project on the branch `feature/FP-2030-add-visible-backdrop-on-select-popover`
- Run `npm run storybook`
- Open the "Select" story and test using "multiple" control as true and false