### PR TITLE
Tags with string values / date filtering fixes / column and dupes

### DIFF
--- a/src/Components/Logs/LogsTable/LogsTable.js
+++ b/src/Components/Logs/LogsTable/LogsTable.js
@@ -83,7 +83,7 @@ const MuiVirtualizedTable = props => {
     style={{ height: rowHeight }}
   >
     {row[column.dataKey]}
-  </TableCell>)), []);
+  </TableCell>)), [columns]);
 
   const CustomTable = useCallback(
     React.forwardRef((props, ref) => <Table ref={ref} {...props} className={classes.table} />),
@@ -120,7 +120,7 @@ const MuiVirtualizedTable = props => {
     <TableRow className={classes.tableHead}>
       {columns.map(headerRender)}
     </TableRow>
-  ), [classes]);
+  ), [classes, columns]);
 
   if (!data.length)
     return (
@@ -131,7 +131,7 @@ const MuiVirtualizedTable = props => {
           </TableRow>
         </TableHead>
         <TableBody>
-          <TableRow>
+          <TableRow data-testid="no-rows">
             <TableCell colSpan={columns.length} className={classes.noRows}>
               { i18n.t("No matches found") }
             </TableCell>


### PR DESCRIPTION
All of these errors were introduced AFTER the last delivery of fleetmanager and ide and not before.
The filters were INDEED failing in some situations, namely prod apps, because of conflicting react installations.
And how new react works differently. In instances where react was the old one, it worked the same. In others, it didn't.
pnpm was introduced to deal with this. And prevent duplicate important dependencies. Specifically, react and mui ones.