### PR TITLE
[1.3.2-17]: FP-2741: Odd message when trying to start another flow when one is ru…

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -9,6 +9,9 @@ i18n.init({
   fallbackLng: false,
   debug: false,
   missingKeyHandler: (_lng, _ns, key, fallbackValue) => fallbackValue ?? key,
+  interpolation: {
+    escape: a => a,
+  }
 });
 export { Translations };
 export default i18n;


### PR DESCRIPTION
- [FP-2741](https://movai.atlassian.net/browse/FP-2741): Odd message when trying to start another flow when one is running
  - Notes:
    - Internationalization doesn't need to escape strings in a react context