### PR TITLE
FP-2848: Review and enable lib-core unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /.pnp
 .pnp.js
 
+# Optional npm cache directory
+.npm
+.pnpm-store
+
 # testing
 /coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-- [FP-2607](https://movai.atlassian.net/browse/FP-2607): Bad styles depending on dependency tree (lib-react problem) - detected in fleet
-- [FP-2616](https://movai.atlassian.net/browse/FP-2607): Improve switch style
-- [FP-2557](https://movai.atlassian.net/browse/FP-2557):  Removing frontend callbacks from backend
-- [FP-2558](https://movai.atlassian.net/browse/FP-2558): implement log streaming
-- [FP-2657](https://movai.atlassian.net/browse/FP-2657): Users with only read permissions can change the scene
+# Version to be assign
+
+- [FP-2848 - Review and enable lib-react unit tests](https://movai.atlassian.net/browse/FP-2848)
+
+# 1.3.4
+
+- [FP-2607 - Bad styles depending on dependency tree (lib-react problem) - detected in fleet](https://movai.atlassian.net/browse/FP-2607)
+- [FP-2616 - Improve switch style](https://movai.atlassian.net/browse/FP-2607) 
+- [FP-2557 - Removing frontend callbacks from backend](https://movai.atlassian.net/browse/FP-2557)
+- [FP-2558 - Implement log streaming](https://movai.atlassian.net/browse/FP-2558)
+- [FP-2657 - Users with only read permissions can change the scene](https://movai.atlassian.net/browse/FP-2657)


### PR DESCRIPTION
[FP-2848](https://movai.atlassian.net/browse/FP-2848)

* lib-react already has a sweep of unit tests (including the base smoke test)
* Added .pnpm-store to .gitignore to prevent the push of thousands of files created by pnpm as cache.