### PR TITLE
FP-2206: IDE- 'current password' field behaves as mandatory but does …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # TBD
 
+- [FP-2206](https://movai.atlassian.net/browse/FP-2206): IDE- 'current password' field behaves as mandatory but does not marked with asterisk
 - [FP-3034](https://movai.atlassian.net/browse/FP-3034): Logs - Do not select backend by default
 
 # v1.3.9

--- a/src/Components/ProfileMenu/ResetPassword.js
+++ b/src/Components/ProfileMenu/ResetPassword.js
@@ -294,6 +294,7 @@ const ResetPasswordModal = forwardRef((props, ref) => {
                 id={FORM_FIELDS.CURRENT_PASSWORD}
                 onChange={handleChange}
                 variant="outlined"
+                required
               />
             )}
             <TextField


### PR DESCRIPTION
- [FP-2206](https://movai.atlassian.net/browse/FP-2206): IDE- 'current password' field behaves as mandatory but does not marked with asterisk


[FP-2206]: https://movai.atlassian.net/browse/FP-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ