### PR TITLE
FP-3224: OPERATOR Role is no longer able to change it's own password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # TBD
 
+- [FP-3224](https://movai.atlassian.net/browse/FP-3224): User with "Operator" permissions is able to change it's own password
 - [FP-3138](https://movai.atlassian.net/browse/FP-3138): Not able to use dev container in all frontend repos
 
 # v1.3.11


### PR DESCRIPTION
[FP-3224](https://movai.atlassian.net/browse/FP-3224)

* OPERATOR Role is no longer able to change it's own password
* This is "operating" on the premise that we have a role called OPERATOR and that it is the one we want to disabled the option to change password.

[FP-3224]: https://movai.atlassian.net/browse/FP-3224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ